### PR TITLE
Custom field type Bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Please report any bugs, feature requests or other issues [here](https://github.c
 
 ### Changelog
 
-#### 0.1.2
+#### 0.1.3
 
 * Custom field type bugfix
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Please report any bugs, feature requests or other issues [here](https://github.c
 
 #### 0.1.2
 
+* Custom field type bugfix
+
+#### 0.1.2
+
 * Bugfix
 
 #### 0.1.1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Reasons 
-## v. 0.1.2
+## v. 0.1.3
 
 _Supercharge your field layouts with conditionals._  
 

--- a/reasons/ReasonsPlugin.php
+++ b/reasons/ReasonsPlugin.php
@@ -14,7 +14,7 @@
 class ReasonsPlugin extends BasePlugin
 {
 
-    protected   $_version = '0.1.2',
+    protected   $_version = '0.1.3',
                 $_developer = 'Mats Mikkel Rummelhoff',
                 $_developerUrl = 'http://mmikkel.no',
                 $_pluginName = 'Reasons',

--- a/reasons/resources/js/reasons.js
+++ b/reasons/resources/js/reasons.js
@@ -1093,18 +1093,22 @@ Reasons.EditForm = Garnish.Base.extend({
 
         this.$fields.each(function(){
             $field = $(this);
-            fieldHandle = $field.attr('id').split('-')[1] || false;
-            fieldId = Reasons.getFieldIdByHandle(fieldHandle);
-            if (fieldId){
-                $field.attr('data-id',fieldId);
-            }
-            // Is this a target field?
-            if (self.conditionals[fieldId]){
-                $field.attr('data-target',1);
-            }
-            // Is this a toggle field
-            if (toggleFieldIds.indexOf(parseInt(fieldId)) > -1){
-                $field.attr('data-toggle',1);
+            fieldIdAttr = $field.attr('id');
+            if( typeof fieldIdAttr !== typeof undefined && fieldIdAttr !== false )
+            {
+                fieldHandle = fieldIdAttr.split('-')[1] || false;
+                fieldId = Reasons.getFieldIdByHandle(fieldHandle);
+                if (fieldId){
+                    $field.attr('data-id',fieldId);
+                }
+                // Is this a target field?
+                if (self.conditionals[fieldId]){
+                    $field.attr('data-target',1);
+                }
+                // Is this a toggle field
+                if (toggleFieldIds.indexOf(parseInt(fieldId)) > -1){
+                    $field.attr('data-toggle',1);
+                }
             }
         });
 


### PR DESCRIPTION
Fixed an issue where the field selector was throwing an error when it couldn't find an id on a custom fieldtype.

Added a check to ensure that the id attr was set prior to processing it.
